### PR TITLE
[CI test] Verify run_all_ui_tests wiring for iOS pr.yaml

### DIFF
--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -4,7 +4,9 @@
 warn("Big PR, try to keep changes smaller if you can.", sticky: true) if git.lines_of_code > 1000
 
 # Redirect contributors to PR to dev.
-fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if github.branch_for_base != "dev"
+# [Test-only] Allow fix-run-all-ui-tests-on-authflowtester-change base for fork CI verification
+allowed_bases = ["dev", "fix-run-all-ui-tests-on-authflowtester-change"]
+fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) unless allowed_bases.include?(github.branch_for_base)
 
 # List of supported xcode schemes for testing
 SCHEMES = ['SalesforceSDKCommon', 'SalesforceAnalytics', 'SalesforceSDKCore', 'SmartStore', 'MobileSync']

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   # pull_request_target is used so secrets are available to fork PRs.
   # Mitigated by per-job Member Check (see "Check Write Permission" / "Validate Write Permission").
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master]
+    branches: [dev, master, fix-run-all-ui-tests-on-authflowtester-change]
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'


### PR DESCRIPTION
DO NOT MERGE — fork CI verification only for upstream PR. Validates that the run_all_ui_tests output is correctly wired through test-orchestrator → ui-tests-pr with no startup_failure.